### PR TITLE
Fix social icons on smaller devices

### DIFF
--- a/components/social-links.js
+++ b/components/social-links.js
@@ -23,7 +23,7 @@ function SocialLinks() {
         </svg>
       </a>
       <a
-        className="c-light ml-32"
+        className="c-light ml-16 ml-lg-32"
         href="https://kommunity.com/kanvas-tasarim-toplulugu"
         target="_blank"
         rel="noopener noreferrer"
@@ -43,7 +43,7 @@ function SocialLinks() {
         </svg>
       </a>
       <a
-        className="c-light ml-32"
+        className="c-light ml-16 ml-lg-32"
         href="https://instagram.com/kanvas_tt"
         target="_blank"
         rel="noopener noreferrer"
@@ -63,7 +63,7 @@ function SocialLinks() {
         </svg>
       </a>
       <a
-        className="c-light ml-32"
+        className="c-light ml-16 ml-lg-32"
         href="mailto:merhaba@kanvas.istanbul"
         target="_blank"
         rel="noopener noreferrer"
@@ -83,7 +83,7 @@ function SocialLinks() {
         </svg>
       </a>
       <a
-        className="c-light ml-32"
+        className="c-light ml-16 ml-lg-32"
         href="https://t.me/kanvastt"
         target="_blank"
         rel="noopener noreferrer"
@@ -103,7 +103,7 @@ function SocialLinks() {
         </svg>
       </a>
       <a
-        className="c-light ml-32"
+        className="c-light ml-16 ml-lg-32"
         href="https://www.youtube.com/channel/UCnYHPOiDxbYguqfBAKuWa0w/featured"
         target="_blank"
         rel="noopener noreferrer"


### PR DESCRIPTION
Social icons spacing changed for smaller devices.

![Screenshot from 2020-09-15 13-23-43](https://user-images.githubusercontent.com/3390175/93199926-c191e180-f757-11ea-90fc-4f8fb431111f.png) ![Screenshot from 2020-09-15 13-23-23](https://user-images.githubusercontent.com/3390175/93199920-bfc81e00-f757-11ea-8328-39ea6c092153.png)
